### PR TITLE
Fix move-assign bug, refactor RVPT perframe data

### DIFF
--- a/src/rvpt/rvpt.cpp
+++ b/src/rvpt/rvpt.cpp
@@ -25,66 +25,58 @@ bool RVPT::initialize()
 
     create_framebuffers();
 
-    // output image
+    rendering_resources = create_rendering_resources();
 
-    sampled_image.emplace(
-        vk_device, memory_allocator, *graphics_queue, VK_FORMAT_R8G8B8A8_UNORM,
-        VK_IMAGE_TILING_OPTIMAL, 512, 512, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT,
-        VK_IMAGE_LAYOUT_GENERAL, static_cast<VkDeviceSize>(512 * 512 * 4), VK::MemoryUsage::gpu);
+    for (int i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
+    {
+        // resources
+        per_frame_output_image.emplace_back(
+            vk_device, memory_allocator, *graphics_queue, VK_FORMAT_R8G8B8A8_UNORM,
+            VK_IMAGE_TILING_OPTIMAL, 512, 512,
+            VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_LAYOUT_GENERAL,
+            static_cast<VkDeviceSize>(512 * 512 * 4), VK::MemoryUsage::gpu);
+        per_frame_uniform_buffer.emplace_back(vk_device, memory_allocator,
+                                              VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 16,
+                                              VK::MemoryUsage::cpu_to_gpu);
+        per_frame_raytrace_command_buffer.emplace_back(
+            vk_device, compute_queue.has_value() ? *compute_queue : *graphics_queue);
+        per_frame_raytrace_work_fence.emplace_back(vk_device);
 
-    std::vector<VkDescriptorSetLayoutBinding> layout_bindings = {
-        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+        // descriptor sets
+        per_frame_descriptor_sets.push_back(
+            {rendering_resources->image_pool.allocate(),
+             rendering_resources->raytrace_descriptor_pool.allocate()});
 
-    sampled_image_pool.emplace(vk_device, layout_bindings, 1);
-    sampled_image_descriptor_set = sampled_image_pool->allocate();
+        // update descriptor sets with resources
+        std::vector<VkDescriptorImageInfo> image_descriptor_info = {
+            per_frame_output_image[i].descriptor_info()};
+        VK::DescriptorUse descriptor_use{0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                         image_descriptor_info};
 
-    std::vector<VkDescriptorImageInfo> image_descriptor_info = {sampled_image->descriptor_info()};
-    VK::DescriptorUse descriptor_use{0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                     image_descriptor_info};
+        auto write_descriptor = descriptor_use.get_write_descriptor_set(
+            per_frame_descriptor_sets[i].image_descriptor_set.set);
+        vkUpdateDescriptorSets(vk_device, 1, &write_descriptor, 0, nullptr);
 
-    auto write_descriptor =
-        descriptor_use.get_write_descriptor_set(sampled_image_descriptor_set->set);
-    vkUpdateDescriptorSets(vk_device, 1, &write_descriptor, 0, nullptr);
+        per_frame_uniform_buffer[i].map();
+        glm::vec4 background_color{0.2f, 0.3f, 0.4f, 0.5f};
+        per_frame_uniform_buffer[i].copy_to(background_color);
 
-    fullscreen_triangle_pipeline = pipeline_builder.create_graphics_pipeline(
-        "fullscreen_tri.vert.spv", "tex_sample.frag.spv", {sampled_image_descriptor_set->layout},
-        fullscreen_tri_render_pass, vkb_swapchain.extent);
+        VK::DescriptorUse image_descriptor_use{0, 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                               image_descriptor_info};
 
-    // Compute
+        std::vector<VkDescriptorBufferInfo> buffer_descriptor_info = {
+            per_frame_uniform_buffer[i].descriptor_info()};
+        VK::DescriptorUse buffer_descriptor_use{1, 1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                                buffer_descriptor_info};
 
-    uniform_buffer.emplace(vk_device, memory_allocator, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 16,
-                           VK::MemoryUsage::cpu_to_gpu);
-    uniform_buffer->map();
-    glm::vec4 background_color{0.2f, 0.3f, 0.4f, 0.5f};
-    uniform_buffer->copy_to(background_color);
+        VkWriteDescriptorSet write_descriptors[] = {
+            image_descriptor_use.get_write_descriptor_set(
+                per_frame_descriptor_sets[i].raytracing_descriptor_sets.set),
+            buffer_descriptor_use.get_write_descriptor_set(
+                per_frame_descriptor_sets[i].raytracing_descriptor_sets.set)};
 
-    std::vector<VkDescriptorSetLayoutBinding> compute_layout_bindings = {
-        {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-
-    compute_descriptor_pool.emplace(vk_device, compute_layout_bindings, 1);
-    compute_descriptor_set = compute_descriptor_pool->allocate();
-
-    VK::DescriptorUse image_descriptor_use{0, 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                           image_descriptor_info};
-
-    std::vector<VkDescriptorBufferInfo> buffer_descriptor_info = {
-        uniform_buffer->descriptor_info()};
-    VK::DescriptorUse buffer_descriptor_use{1, 1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                                            buffer_descriptor_info};
-
-    VkWriteDescriptorSet write_descriptors[] = {
-        image_descriptor_use.get_write_descriptor_set(compute_descriptor_set->set),
-        buffer_descriptor_use.get_write_descriptor_set(compute_descriptor_set->set)};
-
-    vkUpdateDescriptorSets(vk_device, 2, write_descriptors, 0, nullptr);
-
-    compute_pipeline = pipeline_builder.create_compute_pipeline("compute_pass.comp.spv",
-                                                                {compute_descriptor_set->layout});
-
-    compute_command_buffer.emplace(vk_device,
-                                   compute_queue.has_value() ? *compute_queue : *graphics_queue);
-    compute_work_fence.emplace(vk_device);
+        vkUpdateDescriptorSets(vk_device, 2, write_descriptors, 0, nullptr);
+    }
 
     return init;
 }
@@ -92,13 +84,14 @@ bool RVPT::update() { return true; }
 
 RVPT::draw_return RVPT::draw()
 {
-    compute_work_fence->wait();
-    compute_work_fence->reset();
+    per_frame_raytrace_work_fence[current_frame_index].wait();
+    per_frame_raytrace_work_fence[current_frame_index].reset();
 
     record_compute_command_buffer();
 
     VK::Queue& compute_submit = compute_queue.has_value() ? *compute_queue : *graphics_queue;
-    compute_submit.submit(compute_command_buffer.value(), compute_work_fence.value());
+    compute_submit.submit(per_frame_raytrace_command_buffer[current_frame_index],
+                          per_frame_raytrace_work_fence[current_frame_index]);
 
     auto& current_frame = sync_resources[current_frame_index];
 
@@ -154,15 +147,11 @@ void RVPT::shutdown()
     graphics_queue->wait_idle();
     present_queue->wait_idle();
 
-    uniform_buffer.reset();
-
-    compute_work_fence.reset();
-    compute_command_buffer.reset();
-
-    compute_descriptor_pool.reset();
-
-    sampled_image_pool.reset();
-    sampled_image.reset();
+    per_frame_output_image.clear();
+    per_frame_uniform_buffer.clear();
+    per_frame_raytrace_command_buffer.clear();
+    per_frame_raytrace_work_fence.clear();
+    rendering_resources.reset();
 
     VK::destroy_render_pass(vk_device, fullscreen_tri_render_pass);
 
@@ -317,18 +306,43 @@ void RVPT::create_framebuffers()
     }
 }
 
+RVPT::RenderingResources RVPT::create_rendering_resources()
+{
+    std::vector<VkDescriptorSetLayoutBinding> layout_bindings = {
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+
+    auto image_pool = VK::DescriptorPool(vk_device, layout_bindings, MAX_FRAMES_IN_FLIGHT);
+
+    std::vector<VkDescriptorSetLayoutBinding> compute_layout_bindings = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+
+    auto raytrace_descriptor_pool =
+        VK::DescriptorPool(vk_device, compute_layout_bindings, MAX_FRAMES_IN_FLIGHT);
+
+    auto fullscreen_triangle_pipeline = pipeline_builder.create_graphics_pipeline(
+        "fullscreen_tri.vert.spv", "tex_sample.frag.spv", {image_pool.layout()},
+        fullscreen_tri_render_pass, vkb_swapchain.extent);
+
+    auto raytrace_pipeline = pipeline_builder.create_compute_pipeline(
+        "compute_pass.comp.spv", {raytrace_descriptor_pool.layout()});
+
+    return RVPT::RenderingResources{std::move(image_pool), std::move(raytrace_descriptor_pool),
+                                    fullscreen_triangle_pipeline, raytrace_pipeline};
+}
+
 void RVPT::record_command_buffer(VK::SyncResources& current_frame, uint32_t swapchain_image_index)
 {
     current_frame.command_buffer.begin();
     VkCommandBuffer cmd_buf = current_frame.command_buffer.get();
 
-    // Image memory barrier to make sure that compute shader writes are finished
-    // before sampling from the texture
+    // Image memory barrier to make sure that compute shader writes are
+    // finished before sampling from the texture
     VkImageMemoryBarrier imageMemoryBarrier = {};
     imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
     imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    imageMemoryBarrier.image = sampled_image->image.handle;
+    imageMemoryBarrier.image = per_frame_output_image[current_frame_index].image.handle;
     imageMemoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
     imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
@@ -362,10 +376,11 @@ void RVPT::record_command_buffer(VK::SyncResources& current_frame, uint32_t swap
     vkCmdSetScissor(cmd_buf, 0, 1, &scissor);
 
     vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                      fullscreen_triangle_pipeline.pipeline);
-    vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                            fullscreen_triangle_pipeline.layout, 0, 1,
-                            &sampled_image_descriptor_set->set, 0, nullptr);
+                      rendering_resources->fullscreen_triangle_pipeline.pipeline);
+    vkCmdBindDescriptorSets(
+        cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS,
+        rendering_resources->fullscreen_triangle_pipeline.layout, 0, 1,
+        &per_frame_descriptor_sets[current_frame_index].image_descriptor_set.set, 0, nullptr);
     vkCmdDraw(cmd_buf, 3, 1, 0, 0);
     vkCmdEndRenderPass(cmd_buf);
     current_frame.command_buffer.end();
@@ -373,13 +388,17 @@ void RVPT::record_command_buffer(VK::SyncResources& current_frame, uint32_t swap
 
 void RVPT::record_compute_command_buffer()
 {
-    compute_command_buffer->begin();
-    VkCommandBuffer cmd_buf = compute_command_buffer->get();
-    vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipeline.pipeline);
-    vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipeline.layout, 0, 1,
-                            &compute_descriptor_set->set, 0, 0);
+    auto& command_buffer = per_frame_raytrace_command_buffer[current_frame_index];
+    command_buffer.begin();
+    VkCommandBuffer cmd_buf = command_buffer.get();
+    vkCmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE,
+                      rendering_resources->raytrace_pipeline.pipeline);
+    vkCmdBindDescriptorSets(
+        cmd_buf, VK_PIPELINE_BIND_POINT_COMPUTE, rendering_resources->raytrace_pipeline.layout, 0,
+        1, &per_frame_descriptor_sets[current_frame_index].raytracing_descriptor_sets.set, 0, 0);
 
-    vkCmdDispatch(cmd_buf, sampled_image->width / 16, sampled_image->height / 16, 1);
+    vkCmdDispatch(cmd_buf, per_frame_output_image[current_frame_index].width / 16,
+                  per_frame_output_image[current_frame_index].height / 16, 1);
 
-    compute_command_buffer->end();
+    command_buffer.end();
 }

--- a/src/rvpt/rvpt.h
+++ b/src/rvpt/rvpt.h
@@ -76,21 +76,31 @@ private:
     std::vector<VkFence> frames_inflight_fences;
 
     VkRenderPass fullscreen_tri_render_pass;
-    VK::Pipeline fullscreen_triangle_pipeline;
 
     std::vector<VK::Framebuffer> framebuffers;
 
-    std::optional<VK::Image> sampled_image;
-    std::optional<VK::DescriptorPool> sampled_image_pool;
-    std::optional<VK::DescriptorSet> sampled_image_descriptor_set;
+    struct RenderingResources
+    {
+        VK::DescriptorPool image_pool;
 
-    std::optional<VK::DescriptorPool> compute_descriptor_pool;
-    std::optional<VK::DescriptorSet> compute_descriptor_set;
-    VK::Pipeline compute_pipeline;
-    std::optional<VK::CommandBuffer> compute_command_buffer;
-    std::optional<VK::Fence> compute_work_fence;
+        VK::DescriptorPool raytrace_descriptor_pool;
 
-    std::optional<VK::Buffer> uniform_buffer;
+        VK::Pipeline fullscreen_triangle_pipeline;
+        VK::Pipeline raytrace_pipeline;
+    };
+
+    struct PerFrameDescriptorSets
+    {
+        VK::DescriptorSet image_descriptor_set;
+        VK::DescriptorSet raytracing_descriptor_sets;
+    };
+
+    std::optional<RenderingResources> rendering_resources;
+    std::vector<VK::Image> per_frame_output_image;
+    std::vector<VK::Buffer> per_frame_uniform_buffer;
+    std::vector<VK::CommandBuffer> per_frame_raytrace_command_buffer;
+    std::vector<VK::Fence> per_frame_raytrace_work_fence;
+    std::vector<PerFrameDescriptorSets> per_frame_descriptor_sets;
 
     // helper functions
     bool context_init();
@@ -98,6 +108,9 @@ private:
     bool swapchain_reinit();
     bool swapchain_get_images();
     void create_framebuffers();
+
+    RenderingResources create_rendering_resources();
+    PerFrameDescriptorSets create_per_frame_descriptor_sets();
 
     void record_command_buffer(VK::SyncResources& current_frame, uint32_t swapchain_image_index);
     void record_compute_command_buffer();

--- a/src/rvpt/vk_util.h
+++ b/src/rvpt/vk_util.h
@@ -54,10 +54,18 @@ public:
     }
     HandleWrapper& operator=(HandleWrapper&& other) noexcept
     {
-        device = other.device;
-        handle = other.handle;
-        deleter = other.deleter;
-        other.handle = nullptr;
+        if (this != &other)
+        {
+            if (handle != nullptr)
+            {
+                deleter(device, handle, nullptr);
+            }
+
+            device = other.device;
+            handle = other.handle;
+            deleter = other.deleter;
+            other.handle = nullptr;
+        }
         return *this;
     }
 
@@ -134,8 +142,8 @@ public:
     explicit CommandBuffer(VkDevice device, Queue const& queue);
     ~CommandBuffer();
 
-    CommandBuffer(CommandBuffer const& fence) = delete;
-    CommandBuffer& operator=(CommandBuffer const& fence) = delete;
+    CommandBuffer(CommandBuffer const& other) = delete;
+    CommandBuffer& operator=(CommandBuffer const& other) = delete;
     CommandBuffer(CommandBuffer&& other) noexcept;
     CommandBuffer& operator=(CommandBuffer&& other) noexcept;
 
@@ -214,8 +222,10 @@ public:
     DescriptorSet allocate();
     void free(DescriptorSet set);
 
+    VkDescriptorSetLayout layout();
+
 private:
-    HandleWrapper<VkDescriptorSetLayout, PFN_vkDestroyDescriptorSetLayout> layout;
+    HandleWrapper<VkDescriptorSetLayout, PFN_vkDestroyDescriptorSetLayout> vk_layout;
     HandleWrapper<VkDescriptorPool, PFN_vkDestroyDescriptorPool> pool;
     uint32_t max_sets = 0;
     uint32_t current_sets = 0;
@@ -275,6 +285,7 @@ enum class MemoryUsage
     gpu_to_cpu,
     cpu_copy
 };
+
 class MemoryAllocator
 {
 public:
@@ -283,8 +294,40 @@ public:
 
     void shutdown();
 
-    bool allocate_image(VkImage image, VkDeviceSize size, MemoryUsage usage);
-    bool allocate_buffer(VkBuffer buffer, VkDeviceSize size, MemoryUsage usage);
+    template <typename T>
+    struct Allocation
+    {
+        Allocation(MemoryAllocator* memory_ptr, T data) : memory_ptr(memory_ptr), data(data) {}
+        ~Allocation()
+        {
+            if (data != VK_NULL_HANDLE) memory_ptr->free(data);
+        }
+
+        Allocation(Allocation const& other) noexcept = delete;
+        Allocation& operator=(Allocation const& other) noexcept = delete;
+
+        Allocation(Allocation&& other) noexcept : memory_ptr(other.memory_ptr), data(other.data)
+        {
+            other.data = VK_NULL_HANDLE;
+        }
+        Allocation& operator=(Allocation&& other) noexcept
+        {
+            if (this != &other)
+            {
+                if (data != VK_NULL_HANDLE) memory_ptr->free(data);
+                memory_ptr = other.memory_ptr;
+                data = other.data;
+                other.data = VK_NULL_HANDLE;
+            }
+            return *this;
+        }
+
+        MemoryAllocator* memory_ptr;
+        T data;
+    };
+
+    Allocation<VkImage> allocate_image(VkImage image, VkDeviceSize size, MemoryUsage usage);
+    Allocation<VkBuffer> allocate_buffer(VkBuffer buffer, VkDeviceSize size, MemoryUsage usage);
 
     void free(VkImage image);
     void free(VkBuffer buffer);
@@ -312,14 +355,14 @@ private:
     VkDevice device;
     VkPhysicalDeviceMemoryProperties memory_properties;
 
-    struct Allocation
+    struct InternalAllocation
     {
         VkDeviceSize size;
         HandleWrapper<VkDeviceMemory, PFN_vkFreeMemory> memory;
     };
 
-    std::vector<std::pair<VkImage, Allocation>> image_allocations;
-    std::vector<std::pair<VkBuffer, Allocation>> buffer_allocations;
+    std::vector<std::pair<VkImage, InternalAllocation>> image_allocations;
+    std::vector<std::pair<VkBuffer, InternalAllocation>> buffer_allocations;
 
     VkMemoryPropertyFlags get_memory_property_flags(MemoryUsage usage);
 
@@ -327,8 +370,6 @@ private:
 
     HandleWrapper<VkDeviceMemory, PFN_vkFreeMemory> create_device_memory(VkDeviceSize max_size,
                                                                          uint32_t memory_type);
-    //        VkMemoryRequirements memRequirements, VkMemoryPropertyFlags
-    //        properties);
 };
 
 class Image
@@ -337,13 +378,12 @@ public:
     explicit Image(VkDevice device, MemoryAllocator& memory, Queue& queue, VkFormat format,
                    VkImageTiling tiling, uint32_t width, uint32_t height, VkImageUsageFlags usage,
                    VkImageLayout layout, VkDeviceSize size, MemoryUsage memory_usage);
-    ~Image();
 
     VkDescriptorImageInfo descriptor_info() const;
 
     MemoryAllocator* memory_ptr;
     HandleWrapper<VkImage, PFN_vkDestroyImage> image;
-    bool successfully_got_memory;
+    MemoryAllocator::Allocation<VkImage> image_allocation;
     HandleWrapper<VkImageView, PFN_vkDestroyImageView> image_view;
     HandleWrapper<VkSampler, PFN_vkDestroySampler> sampler;
 
@@ -358,7 +398,6 @@ class Buffer
 public:
     explicit Buffer(VkDevice device, MemoryAllocator& memory, VkBufferUsageFlags usage,
                     VkDeviceSize size, MemoryUsage memory_usage);
-    ~Buffer();
 
     void map();
     void unmap();
@@ -380,6 +419,8 @@ public:
 private:
     MemoryAllocator* memory_ptr;
     HandleWrapper<VkBuffer, PFN_vkDestroyBuffer> buffer;
+    MemoryAllocator::Allocation<VkBuffer> buffer_allocation;
+
     VkDeviceSize size;
     bool is_mapped = false;
     void* mapped_ptr = nullptr;


### PR DESCRIPTION
Needed to have multiple copies of some resources, made the necessary
changes to allow for that.
