### PR TITLE
Fix hard coded size for various vectors

### DIFF
--- a/src/rvpt/camera.cpp
+++ b/src/rvpt/camera.cpp
@@ -59,8 +59,8 @@ std::vector<glm::vec4> Camera::get_data()
 void Camera::update_imgui()
 {
     static bool is_active = true;
-    ImGui::SetWindowPos({0, 200});
-    ImGui::SetWindowSize({180, 100});
+    ImGui::SetNextWindowPos({0, 160});
+    ImGui::SetNextWindowSize({200, 180});
 
     if (ImGui::Begin("Camera Data", &is_active))
     {

--- a/src/rvpt/rvpt.h
+++ b/src/rvpt/rvpt.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <optional>
 #include <iostream>
+#include <random>
 
 #include <vulkan/vulkan.h>
 
@@ -70,6 +71,10 @@ private:
 
     // from a callback
     bool framebuffer_resized = false;
+
+    // Random number generators
+    std::mt19937 random_generator;
+    std::uniform_real_distribution<float> distribution;
 
     // Random numbers (generated every frame)
     std::vector<float> random_numbers;


### PR DESCRIPTION
There were several instances of hardcoding size data. This commit uses programmatic
means to get the correct size, to ensure issues do not occur in the future.

Spiffed up where the imgui windows are.
Moved the RNG to be a class variable, so its not being constructed every frame
Moved scene init to before the rvpt init function