### PR TITLE
Add debug_utils names to vulkan objects

### DIFF
--- a/src/rvpt/rvpt.h
+++ b/src/rvpt/rvpt.h
@@ -169,7 +169,7 @@ private:
     void create_framebuffers();
 
     RenderingResources create_rendering_resources();
-    void add_per_frame_data();
+    void add_per_frame_data(int index);
 
     // Todo remove this(PLEASE REMEMBER)
     void addRectangle(glm::vec3, glm::vec3, glm::vec3, glm::vec3, int mat);


### PR DESCRIPTION
This makes it much easier to inspect frame data in capture tools like renderdoc because
most everything is now nicely labeled.