### PR TITLE
Fix validation error about forgotten dynamic state in pipeline create info

### DIFF
--- a/src/rvpt/vk_util.cpp
+++ b/src/rvpt/vk_util.cpp
@@ -759,6 +759,7 @@ VkPipeline PipelineBuilder::create_immutable_pipeline(GraphicsPipelineDetails co
     create_info.pMultisampleState = &multisampling;
     create_info.pDepthStencilState = &depth_stencil_info;
     create_info.pColorBlendState = &color_blending;
+    create_info.pDynamicState = &dynamic_state;
     create_info.layout = details.pipeline_layout;
     create_info.renderPass = details.render_pass;
     create_info.subpass = 0;


### PR DESCRIPTION
Turns out something broke and caused a bunch of validation layer spam. Might fix other crashes at startup.